### PR TITLE
Deploy on Netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "firebase": "^5.8.2",
     "formik": "^1.4.3",
-    "gh-pages": "^2.0.1",
     "leaflet": "^1.4.0",
     "re-base": "^4.0.0",
     "react": "^16.7.0",
@@ -18,8 +17,6 @@
     "yup": "^0.26.10"
   },
   "scripts": {
-    "predeploy": "npm run build",
-    "deploy": "gh-pages -d build",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
@@ -36,6 +33,5 @@
   ],
   "devDependencies": {
     "terser": "^3.14.1"
-  },
-  "homepage": "http://robinmetral.github.io/coffee"
+  }
 }


### PR DESCRIPTION
I've extensively tested ([PageSpeed Insights](https://developers.google.com/speed/pagespeed/insights/), [Lighthouse](https://github.com/GoogleChrome/lighthouse/), and [WebPageTest](https://www.webpagetest.org/)) the performance of the app deployed:
 1. On GitHub Pages
 2. On Netlify

The results are very similar, as seen on these screenshots:

GitHub Pages | Netlify
------------------ | ---------
![github-3-webpagetest](https://user-images.githubusercontent.com/35560568/53161279-0086a200-35ca-11e9-9893-8c52088f2e2b.png) | ![netlify-3-webpagetest](https://user-images.githubusercontent.com/35560568/53161289-067c8300-35ca-11e9-9968-d4c10a9e56cb.png)

Netlify seems to be doing a better job on second run, however WebPageTest didn't finish to load the cafes (the map is empty on Netlify after 2s, but populated on GitHub Pages after 6s).

The difference is negligible, so I'll switch to Netlify in order to get rid of additional scripts (`npm run deploy`, `npm run predeploy`), a branch (`gh-pages`) and the GitHub Pages dependency.